### PR TITLE
Upgrade Sphinx to v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM leodido/sphinxsearch:2.2.10
+FROM vanillaryan/sphinxsearch
 
-RUN yum install sed \
-  && yum install -y epel-release \
-  && sed -i "s/mirrorlist=https/mirrorlist=http/" /etc/yum.repos.d/epel.repo \
-  && yum clean all && yum install -y compat-readline5 \
-  && yum clean all && yum install -y socat \
+RUN yum install epel-release mysql mysql-devel python3 socat -y
   && mkdir -p /usr/local/etc/sphinx \
   && mkdir -p /usr/local/etc/sphinx/conf.d \
   && mkdir -p /usr/local/etc/sphinx/data


### PR DESCRIPTION
Swapping out `leodido/sphinxsearch` for `vanillaryan/sphinxsearch`. The upgrade in CentOS versions also necessitates some package updates.