### PR TITLE
Update sphinx templates to match some global queries

### DIFF
--- a/usr/local/etc/sphinx/conf.d/vanilla.conf
+++ b/usr/local/etc/sphinx/conf.d/vanilla.conf
@@ -357,6 +357,7 @@ source {MYSQL_DATABASE}_Discussion {
             DiscussionID, \
             CategoryID, \
             0 as knowledgeCategoryID, \
+            0 as GroupID, \
             InsertUserID, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
@@ -371,6 +372,7 @@ source {MYSQL_DATABASE}_Discussion {
     sql_attr_uint = DiscussionID
     sql_attr_uint = CategoryID
     sql_attr_uint = knowledgeCategoryID
+    sql_attr_uint = GroupID
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
     sql_attr_float = Score
@@ -391,6 +393,7 @@ source {MYSQL_DATABASE}_Discussion_Delta: {MYSQL_DATABASE}_Discussion {
             DiscussionID, \
             CategoryID, \
             0 as knowledgeCategoryID, \
+            0 as GroupID, \
             InsertUserID, \
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
@@ -431,6 +434,7 @@ source {MYSQL_DATABASE}_Comment {
             c.DiscussionID, \
             d.CategoryID, \
             0 as knowledgeCategoryID, \
+            0 as GroupID, \
             c.InsertUserID, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
@@ -444,6 +448,7 @@ source {MYSQL_DATABASE}_Comment {
             CommentID <= $end
     sql_attr_uint = CategoryID
     sql_attr_uint = knowledgeCategoryID
+    sql_attr_uint = GroupID
     sql_attr_uint = DiscussionID
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
@@ -460,6 +465,7 @@ source {MYSQL_DATABASE}_Comment_Delta: {MYSQL_DATABASE}_Comment {
             c.DiscussionID, \
             d.CategoryID, \
             0 as knowledgeCategoryID, \
+            0 as GroupID, \
             c.InsertUserID, \
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
@@ -503,6 +509,7 @@ source {MYSQL_DATABASE}_KnowledgeArticle {
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
+            0 as GroupID, \
             a.knowledgeCategoryID, \
             a.insertUserID, \
             a.updateUserID, \
@@ -531,6 +538,7 @@ source {MYSQL_DATABASE}_KnowledgeArticle {
                  ar.articleRevisionID <= $end
     sql_attr_bigint = discussionID
     sql_attr_uint = categoryID
+    sql_attr_uint = GroupID
     sql_attr_uint = knowledgeCategoryID
     sql_attr_uint = knowledgeBaseID
     sql_attr_uint = insertUserID
@@ -560,6 +568,7 @@ source {MYSQL_DATABASE}_KnowledgeArticle_Delta: {MYSQL_DATABASE}_KnowledgeArticl
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 0 as CategoryID, \
+                0 as GroupID, \
                 a.knowledgeCategoryID, \
                 a.insertUserID, \
                 a.updateUserID, \
@@ -644,6 +653,7 @@ source {MYSQL_DATABASE}_KnowledgeArticleDeleted {
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
+            0 as GroupID, \
             a.knowledgeCategoryID, \
             a.insertUserID, \
             a.updateUserID, \
@@ -697,6 +707,7 @@ source {MYSQL_DATABASE}_KnowledgeArticleDeleted_Delta: {MYSQL_DATABASE}_Knowledg
                 ar.articleRevisionID, \
                 a.articleID as DiscussionID, \
                 0 as CategoryID, \
+                0 as GroupID, \
                 ar.locale as locale,\
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\

--- a/usr/local/etc/sphinx/conf.d/vanilla.conf
+++ b/usr/local/etc/sphinx/conf.d/vanilla.conf
@@ -769,3 +769,75 @@ index {MYSQL_DATABASE}_KnowledgeArticleDeleted_Delta: {MYSQL_DATABASE}_Knowledge
     source = {MYSQL_DATABASE}_KnowledgeArticleDeleted_Delta
     path = /usr/local/etc/sphinx/data/KnowledgeArticleDeleted_DeltaTest
 }
+
+source {MYSQL_DATABASE}_Group {
+  type = mysql
+  sql_host = {MYSQL_HOST}
+  sql_user = root
+  sql_pass =
+  sql_db = {MYSQL_DATABASE}
+  sql_query_range = SELECT MIN(GroupID),(select MaxID from GDN_SphinxCounter where CounterID = 4) FROM GDN_Group
+  sql_range_step = 10000
+  sql_query_pre = set names utf8
+  sql_query_pre = replace into GDN_SphinxCounter select 4, max(GroupID) from GDN_Group
+  sql_query = select \
+        GroupID * 10 + 4, \
+        GroupID, \
+        3000000000 + GroupID as DiscussionID, \
+        0 as CategoryID, \
+        0 as knowledgeCategoryID, \
+        InsertUserID, \
+        unix_timestamp(DateInserted) as DateInserted, \
+        Name, \
+        Description as Body, \
+        400 as dtype, \
+        0 as IP, \
+        1000 as Score \
+    from GDN_Group \
+    where \
+       GroupID >= $start AND \
+       GroupID <= $end
+  sql_attr_uint = GroupID
+  sql_attr_uint = DiscussionID
+  sql_attr_uint = CategoryID
+  sql_attr_uint = knowledgeCategoryID
+  sql_attr_uint = InsertUserID
+  sql_attr_timestamp = DateInserted
+  sql_attr_float = Score
+  sql_attr_uint = dtype
+  sql_attr_uint = IP
+}
+
+source {MYSQL_DATABASE}_Group_Delta: {MYSQL_DATABASE}_Group {
+  sql_query_range = SELECT (select MaxID from GDN_SphinxCounter where CounterID = 4), MAX(GroupID) FROM GDN_Group
+  sql_query_pre = set names utf8
+  sql_query = select \
+       GroupID * 10 + 4, \
+       GroupID, \
+       3000000000 + GroupID as DiscussionID, \
+       0 as CategoryID, \
+       0 as knowledgeCategoryID, \
+       InsertUserID, \
+       unix_timestamp(DateInserted) as DateInserted, \
+       Name, \
+       Description as Body, \
+       400 as dtype, \
+       0 as IP, \
+       1000 as Score \
+    from GDN_Group \
+    where \
+       GroupID >= $start AND \
+       GroupID <= $end
+}
+
+index {MYSQL_DATABASE}_Group: Base_Charsets {
+  source = {MYSQL_DATABASE}_Group
+  path = /usr/local/etc/sphinx/data/GroupTest
+  morphology = stem_en
+  stopwords = /usr/local/etc/sphinx/data/stops.txt
+}
+
+index {MYSQL_DATABASE}_Group_Delta: {MYSQL_DATABASE}_Group {
+  source = {MYSQL_DATABASE}_Group_Delta
+  path = /usr/local/etc/sphinx/data/Group_DeltaTest
+}


### PR DESCRIPTION
Update sphinx template to have GroupID = 0 and add KnowledgeCategoryID =0 to Group template to match some global queries

Relates to: https://github.com/vanilla/vanilla-cloud/pull/705