### PR TITLE
Add locale_int

### DIFF
--- a/usr/local/etc/sphinx/conf.d/vanilla.conf
+++ b/usr/local/etc/sphinx/conf.d/vanilla.conf
@@ -362,6 +362,7 @@ source {MYSQL_DATABASE}_Discussion {
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
             Body, \
+            CRC32('any') as locale_int, \
             field(Type, 'Question', 'Poll', 'Idea') as dtype, \
             inet_aton(InsertIPAddress) as IP, \
             Score \
@@ -378,6 +379,7 @@ source {MYSQL_DATABASE}_Discussion {
     sql_attr_float = Score
     sql_attr_uint = dtype
     sql_attr_uint = IP
+    sql_attr_uint = locale_int
     sql_attr_multi = uint Tags from ranged-query; \
         select DiscussionID * 10 + 1, TagID \
         from GDN_TagDiscussion \
@@ -398,6 +400,7 @@ source {MYSQL_DATABASE}_Discussion_Delta: {MYSQL_DATABASE}_Discussion {
             unix_timestamp(DateInserted) as DateInserted, \
             Name, \
             Body, \
+            CRC32('any') as locale_int, \
             field(Type, 'Question', 'Poll', 'Idea') as dtype, \
             inet_aton(InsertIPAddress) as IP, \
             Score \
@@ -439,6 +442,7 @@ source {MYSQL_DATABASE}_Comment {
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
             c.Body, \
+            CRC32('any') as locale_int, \
             inet_aton(c.InsertIPAddress) as IP, \
             field(d.Type, 'Question') + 100 as dtype, \
             c.Score \
@@ -453,6 +457,7 @@ source {MYSQL_DATABASE}_Comment {
     sql_attr_uint = InsertUserID
     sql_attr_timestamp = DateInserted
     sql_attr_uint = IP
+    sql_attr_uint = locale_int
     sql_attr_uint = dtype
     sql_attr_float = Score
 }
@@ -470,6 +475,7 @@ source {MYSQL_DATABASE}_Comment_Delta: {MYSQL_DATABASE}_Comment {
             unix_timestamp(c.DateInserted) as DateInserted, \
             concat('RE: ', d.Name) as Name, \
             c.Body, \
+            CRC32('any') as locale_int, \
             inet_aton(c.InsertIPAddress) as IP, \
             field(d.Type, 'Question') + 100 as dtype, \
             c.Score \
@@ -506,6 +512,7 @@ source {MYSQL_DATABASE}_KnowledgeArticle {
             ar.articleRevisionID, \
             4000000000 + ar.articleRevisionID as DiscussionID, \
             ar.locale as locale,\
+            CRC32(ar.locale) as locale_int, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
@@ -547,6 +554,7 @@ source {MYSQL_DATABASE}_KnowledgeArticle {
     sql_attr_string = siteSectionGroup
     sql_attr_uint = dtype
     sql_attr_uint = ip
+    sql_attr_uint = locale_int
     sql_attr_float = score
     sql_attr_timestamp = dateUpdated
     sql_attr_uint = status
@@ -565,6 +573,7 @@ source {MYSQL_DATABASE}_KnowledgeArticle_Delta: {MYSQL_DATABASE}_KnowledgeArticl
                 ar.articleRevisionID, \
                 4000000000 + ar.articleRevisionID as DiscussionID, \
                 ar.locale as locale,\
+                CRC32(ar.locale) as locale_int, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 0 as CategoryID, \
@@ -649,6 +658,7 @@ source {MYSQL_DATABASE}_KnowledgeArticleDeleted {
             ar.articleRevisionID, \
             4000000000 + ar.articleRevisionID as DiscussionID, \
             ar.locale as locale,\
+            CRC32(ar.locale) as locale_int, \
             kb.knowledgeBaseID as KnowledgeBaseID, \
             kb.siteSectionGroup as siteSectionGroup,\
             0 as CategoryID, \
@@ -689,6 +699,7 @@ source {MYSQL_DATABASE}_KnowledgeArticleDeleted {
     sql_attr_string = siteSectionGroup
     sql_attr_uint = dtype
     sql_attr_uint = ip
+    sql_attr_uint = locale_int
     sql_attr_float = score
     sql_attr_timestamp = dateUpdated
     sql_attr_uint = status
@@ -708,6 +719,7 @@ source {MYSQL_DATABASE}_KnowledgeArticleDeleted_Delta: {MYSQL_DATABASE}_Knowledg
                 0 as CategoryID, \
                 0 as GroupID, \
                 ar.locale as locale,\
+                CRC32(ar.locale) as locale_int, \
                 kb.knowledgeBaseID as KnowledgeBaseID, \
                 kb.siteSectionGroup as siteSectionGroup,\
                 a.knowledgeCategoryID, \

--- a/usr/local/etc/sphinx/conf.d/vanilla.conf
+++ b/usr/local/etc/sphinx/conf.d/vanilla.conf
@@ -797,6 +797,7 @@ source {MYSQL_DATABASE}_Group {
         0 as CategoryID, \
         0 as knowledgeCategoryID, \
         InsertUserID, \
+        CRC32('any') as locale_int, \
         unix_timestamp(DateInserted) as DateInserted, \
         Name, \
         Description as Body, \
@@ -812,6 +813,7 @@ source {MYSQL_DATABASE}_Group {
   sql_attr_uint = CategoryID
   sql_attr_uint = knowledgeCategoryID
   sql_attr_uint = InsertUserID
+  sql_attr_uint = locale_int
   sql_attr_timestamp = DateInserted
   sql_attr_float = Score
   sql_attr_uint = dtype
@@ -828,6 +830,7 @@ source {MYSQL_DATABASE}_Group_Delta: {MYSQL_DATABASE}_Group {
        0 as CategoryID, \
        0 as knowledgeCategoryID, \
        InsertUserID, \
+       CRC32('any') as locale_int, \
        unix_timestamp(DateInserted) as DateInserted, \
        Name, \
        Description as Body, \


### PR DESCRIPTION
Introduce new `sql_attr_uint = locale_int` for discussions, coments and articles to allow filtering by int value.

Relates to: https://github.com/vanilla/support/issues/3572
Mirroring changes: https://github.com/vanilla/vanilla-docker/pull/101
Required for: https://github.com/vanilla/vanilla-cloud/pull/2021